### PR TITLE
Add missing sensor type CMFB103F3950FANT

### DIFF
--- a/Firmware/printer-leviathan-rev-d.cfg
+++ b/Firmware/printer-leviathan-rev-d.cfg
@@ -412,6 +412,14 @@ probe_points:
 #####################################################################
 #   TH
 # #####################################################################
+[thermistor CMFB103F3950FANT]
+temperature1: 0.0
+resistance1: 32116.0
+temperature2: 40.0
+resistance2: 5309.0
+temperature3: 80.0
+resistance3: 1228.0
+
 [temperature_sensor chamber_temp]
 ## Chamber Temperature - T1
 sensor_type: ATC Semitec 104NT-4-R025H42G


### PR DESCRIPTION
CMFB103F3950FANT is used as the sensor type for the chamber thermistor but its definition is missing from printer.cfg. This PR adds it in, copied from Nitehawk-SB klipper config.