### PR TITLE
Set rotation_distance correctly for LDO trident kit leadscrews

### DIFF
--- a/Firmware/printer-leviathan-rev-d.cfg
+++ b/Firmware/printer-leviathan-rev-d.cfg
@@ -137,7 +137,7 @@ step_pin: PD4
 dir_pin: PD3
 enable_pin: !PD7
 # Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
-# rotation_distance: 8  
+rotation_distance: 4
 microsteps: 32
 endstop_pin: PC3
 ##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
@@ -178,7 +178,7 @@ step_pin: PC12
 dir_pin: PC11
 enable_pin: !PD2
 # Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
-# rotation_distance: 8  
+rotation_distance: 4
 microsteps: 32
 
 ##  Make sure to update below for your relevant driver (2209 or 5160)
@@ -197,7 +197,7 @@ step_pin: PC9
 dir_pin: PC8
 enable_pin: !PC10
 # Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
-# rotation_distance: 8  
+rotation_distance: 4
 microsteps: 32
 
 ##  Make sure to update below for your relevant driver (2209 or 5160)


### PR DESCRIPTION
LDO Trident kits come with TR8x4 leadscrews, so set rotation_distance: 4 for stepper_z/z1/z2